### PR TITLE
Update README.md

### DIFF
--- a/docs/Guidelines/Coding-Guidelines/README.md
+++ b/docs/Guidelines/Coding-Guidelines/README.md
@@ -14,7 +14,7 @@ The `entity` is the representation of an object.
 ##### Example:
 * a `post`
 * a `document`
-* a `location`
+* a `user` relation 
 
 #### Class Naming
 Classes that represent entities are following the following structure:
@@ -25,7 +25,7 @@ Classes that represent entities are following the following structure:
 ##### Example:
  * `PostEntity` - represents a blog post
  * `DocumentEntity` - represents a document
- * `LocationEntity` - represents a location
+ * `DocuentUserEntity` - represents a document with a user relation
 
 > Note: our recommendation is to name the class attributes (object properties) the same as the column names in persistent storage (database)
 
@@ -38,7 +38,7 @@ Programatically speaking: a `collection` is an iterable set of `entities`.
 ##### Example:
 * a list of `posts`
 * a list of `documents`
-* a list of `locations`
+* a list of `users` in relation to the document
 
 #### Class Naming
 Classes that represent entities are following the following structure:
@@ -48,12 +48,11 @@ Classes that represent entities are following the following structure:
 ##### Example:
  * `PostCollection` - represents a blog post list
  * `DocumentCollection` - represents a document list
- * `LocationCollection` - represents a location list
+ * `DocumentUserCollection` - represents a list of users
  
 
 
 ## Middleware just calls the code
-Entities^TNE^ Classes^TNE^
 
 The "Resources" or the "Middleware" should contain only base operation.
 For instance, queries like `SELECT * FROM (...)` won't be written directly in the middleware
@@ -69,7 +68,9 @@ PUT
 PATCH
 DELETE
 
-Your `services`/`modules`^TNE^ will have interfaces for
+Your `services`/`modules` will have interfaces to make them compatible with any PSR-7 Middleware application-stack.
+
+
 If using `EMS` 
 
-^TNE^ - term needs explanation
+- term needs explanation


### PR DESCRIPTION
Changed one of the examples to also show the readers how a relational-name is composed, in regards to this rule: `Must contain no other words unless they define a relation`

Also removed broken links